### PR TITLE
Use hash_equals for hash comparison to mitigate timing attacks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "league/url": "^3.3"
+        "league/url": "^3.3",
+        "indigophp/hash-compat": "^1.1"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.2",

--- a/src/BaseUrlSigner.php
+++ b/src/BaseUrlSigner.php
@@ -219,6 +219,6 @@ abstract class BaseUrlSigner implements UrlSigner
 
         $validSignature = $this->createSignature($intendedUrl, $expiration);
 
-        return $providedSignature === $validSignature;
+        return hash_equals($validSignature, $providedSignature);
     }
 }


### PR DESCRIPTION
[`hash_equals`](http://php.net/manual/en/function.hash-equals.php) should be used to compare hashes instead of basic string comparison.

It is built into PHP since *5.6*, as this project supports `>=5.5.0` I added [`indigophp/hash-compat`](https://github.com/indigophp/hash-compat) as a polyfill library.

All the tests still pass, I'm sorry not adding new ones but I didn't see how for this change.