### PR TITLE
Replace league/url with league/uri & league/uri-components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 before_script:
   - travis_retry composer install --no-interaction --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,12 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "league/url": "^3.3"
+        "php": "^7.2",
+        "league/uri": "^6.0",
+        "league/uri-components": "^2.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`league/url` has been abandoned since 2015-09-23 and this PR replaces it with its successor: `league/uri` and its components package `league/uri-components`.

The package change requires the minimum PHP version to be set to 7.2. PHPUnit was also updated to the last version that supports PHP7.2.

I know there was concern about requiring new extensions (https://github.com/spatie/url-signer/issues/1) by making the switch, however these are not hard dependencies. If you don't use the `league/uri` i18n URI processing feature (`ext-intl`) or don't want to create a data URI from a filepath (`ext-fileinfo`) then there are no issues – an exception is thrown should you use one of these features and don't have the required extension.

All existing unit tests pass without any modification.

Please let me know if you require any changes to get this PR merged.

Thanks!