### PR TITLE
Use PHP8 version of league/uri-components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "league/uri": "^6.0",
-        "league/uri-components": "^2.3"
+        "league/uri-components": "^2.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "league/uri": "^6.0",
-        "league/uri-components": "dev-master"
+        "league/uri-components": "^2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0"


### PR DESCRIPTION
Use the newly tagged version (https://github.com/thephpleague/uri-components/releases/tag/2.3.0) of league/uri-components which supports PHP-8, instead of using the dev-master dependency. Using the dev-master dependency was giving conflicts when the `minimum-stability` does not allow this.