### PR TITLE
Add missing abstract method in the BaseUrlSigner

### DIFF
--- a/src/BaseUrlSigner.php
+++ b/src/BaseUrlSigner.php
@@ -118,6 +118,16 @@ abstract class BaseUrlSigner implements UrlSigner
 
         return true;
     }
+    
+    /**
+     * Generate a token to identify the secure action.
+     *
+     * @param \League\Url\UrlImmutable|string $url
+     * @param string                          $expiration
+     *
+     * @return string
+     */
+    abstract protected function createSignature($url, $expiration);
 
     /**
      * Check if a query is missing a necessary parameter.

--- a/src/BaseUrlSigner.php
+++ b/src/BaseUrlSigner.php
@@ -122,12 +122,12 @@ abstract class BaseUrlSigner implements UrlSigner
     /**
      * Generate a token to identify the secure action.
      *
-     * @param \League\Url\UrlImmutable|string $url
-     * @param string                          $expiration
+     * @param UriInterface|string $url
+     * @param string              $expiration
      *
      * @return string
      */
-    abstract protected function createSignature($url, $expiration);
+    abstract protected function createSignature($url, string $expiration);
 
     /**
      * Check if a query is missing a necessary parameter.


### PR DESCRIPTION
The class expects child classes to define a createSignature method with the expected API, but it does not enforce that through an abstract method, which is the right way to enforce that.