### PR TITLE
Fix bug validating url without query

### DIFF
--- a/src/BaseUrlSigner.php
+++ b/src/BaseUrlSigner.php
@@ -175,7 +175,7 @@ abstract class BaseUrlSigner implements UrlSigner
         unset($intendedQuery[$this->expiresParameter]);
         unset($intendedQuery[$this->signatureParameter]);
 
-        return $url->withQuery($this->buildQueryStringFromArray($intendedQuery));
+        return $url->withQuery($this->buildQueryStringFromArray($intendedQuery) ?? '');
     }
 
     /**


### PR DESCRIPTION
Signed url validation didn't work if url (intended url) had no query parameter.
Probably a change in league/uri dependency 