### PR TITLE
Bugfix/consistent urlencoding

### DIFF
--- a/src/AbstractUrlSigner.php
+++ b/src/AbstractUrlSigner.php
@@ -36,9 +36,11 @@ abstract class AbstractUrlSigner implements UrlSignerContract
 
         $expiration = $this->getExpirationTimestamp($expiration);
 
-        $signature = $this->createSignature($url, $expiration, $signatureKey);
+        $normalizedUrl = $this->getIntendedUrl($url);
 
-        return $this->signUrl($url, $expiration, $signature);
+        $signature = $this->createSignature($normalizedUrl, $expiration, $signatureKey);
+
+        return $this->signUrl($normalizedUrl, $expiration, $signature);
     }
 
     protected function signUrl(string $url, string $expiration, $signature): string

--- a/src/BaseUrlSigner.php
+++ b/src/BaseUrlSigner.php
@@ -37,9 +37,11 @@ abstract class BaseUrlSigner implements UrlSigner
 
         $expiration = $this->getExpirationTimestamp($expiration);
 
-        $signature = $this->createSignature($url, $expiration, $signatureKey);
+        $normalizedUrl = $this->getIntendedUrl($url);
 
-        return $this->signUrl($url, $expiration, $signature);
+        $signature = $this->createSignature($normalizedUrl, $expiration, $signatureKey);
+
+        return $this->signUrl($normalizedUrl, $expiration, $signature);
     }
 
     protected function signUrl(string $url, string $expiration, $signature): string

--- a/tests/Md5UrlSignerTest.php
+++ b/tests/Md5UrlSignerTest.php
@@ -83,3 +83,27 @@ it('can sign and validate urls with a custom key', function () {
     expect($this->urlSigner->validate($signedUsingCustomKey, 'custom-key'))->toBeTrue();
     expect($this->urlSigner->validate($signedUsingCustomKey, 'wrong-custom-key'))->toBeFalse();
 });
+
+it('can sign url which has special characters in the query parameters', function ($url) {
+    $expiration = 100;
+
+    $signedUrl = $this->urlSigner->sign($url, $expiration);
+
+    expect($this->urlSigner->validate($signedUrl))->toBeTrue();
+})->with([
+    ['https://myapp.com/?foo=bar baz'],
+    ['https://myapp.com/?foo=bar%20baz'],
+    ['https://myapp.com/?foo=bar@baz.com'],
+]);
+
+it('can sign url which has reserved query parameters', function ($url) {
+    $expiration = 100;
+
+    $signedUrl = $this->urlSigner->sign($url, $expiration);
+
+    expect($this->urlSigner->validate($signedUrl))->toBeTrue();
+})->with([
+    ['https://myapp.com/?foo=bar&expires=100&signature=abc123'],
+    ['https://myapp.com/?foo=bar&expires=100'],
+    ['https://myapp.com/?foo=bar&signature=abc123'],
+]);

--- a/tests/Sha256UrlSignerTest.php
+++ b/tests/Sha256UrlSignerTest.php
@@ -92,3 +92,27 @@ it('can sign and validate urls with a custom key', function () {
     expect($this->urlSigner->validate($signedUsingCustomKey, 'custom-key'))->toBeTrue();
     expect($this->urlSigner->validate($signedUsingCustomKey, 'wrong-custom-key'))->toBeFalse();
 });
+
+it('can sign url which has special characters in the query parameters', function ($url) {
+    $expiration = 100;
+
+    $signedUrl = $this->urlSigner->sign($url, $expiration);
+
+    expect($this->urlSigner->validate($signedUrl))->toBeTrue();
+})->with([
+    ['https://myapp.com/?foo=bar baz'],
+    ['https://myapp.com/?foo=bar%20baz'],
+    ['https://myapp.com/?foo=bar@baz.com'],
+]);
+
+it('can sign url which has reserved query parameters', function ($url) {
+    $expiration = 100;
+
+    $signedUrl = $this->urlSigner->sign($url, $expiration);
+
+    expect($this->urlSigner->validate($signedUrl))->toBeTrue();
+})->with([
+    ['https://myapp.com/?foo=bar&expires=100&signature=abc123'],
+    ['https://myapp.com/?foo=bar&expires=100'],
+    ['https://myapp.com/?foo=bar&signature=abc123'],
+]);


### PR DESCRIPTION
https://github.com/spatie/url-signer/issues/56

The proposed change is to "normalize" the url by calling  getIntendedUrl() before calculating the signature in order to ensure the url  is parsed the same way as it is returned after the final signature (appending the expires and signature query params). This way the url is url encoded consistently (special characters in the query params too).

Tests are added to validate this behaviour.

At the same time a test is added for a case when url includes reserved (expires and signature) query param keys. By design, these params are automatically overridden, that I think is the expected behaviour. 
Before this change the validation always failed, because the signature was calculated on the full "raw" url including the reserved query params. However since the original query params are overridden the signature will never not match (at validation the signature is calculated without the reserved query params).